### PR TITLE
Disable double-link checks from awesome-lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: npx awesome-lint@2.0.0
+      - run: npx awesome-lint

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome robot descriptions in URDF, Xacro or MJCF formats.
 ## Robot Descriptions
 
 <!-- lint disable double-link -->
+<!-- lint disable table-cell-padding -->
 <!-- lint disable table-pipe-alignment -->
 
 ### Arms

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A curated list of awesome robot descriptions in URDF, Xacro or MJCF formats.
 
 ## Robot Descriptions
 
-<!--lint disable double-link-->
+<!-- lint disable double-link -->
+<!-- lint disable table-pipe-alignment -->
 
 ### Arms
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A curated list of awesome robot descriptions in URDF, Xacro or MJCF formats.
 
 ## Robot Descriptions
 
+<!--lint disable double-link-->
+
 ### Arms
 
 | Name | Maker | Formats | License | Visuals | Inertias | Collisions |


### PR DESCRIPTION
We can have duplicate license links in this list.