### PR TITLE
Feat/add Stanford TidyBot 

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ A curated list of awesome robot descriptions in URDF, Xacro or MJCF formats.
 | Stretch RE1 | Hello Robot | [URDF](https://github.com/robot-descriptions/stretch_description), [Xacro](https://github.com/hello-robot/stretch_ros/tree/master/stretch_description) | CC-BY-NC-SA-4.0 | ✔️ | ✔️ | ✔️ |
 | TIAGo | PAL Robotics | [URDF](https://github.com/Gepetto/example-robot-data/tree/master/robots/tiago_description), [MJCF](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_tiago), [Xacro](https://github.com/pal-robotics/tiago_robot/blob/kinetic-devel/tiago_description/robots/tiago.urdf.xacro) | Apache-2.0 | ✔️ | ✔️ | ✔️ |
 | Perseverance | NASA JPL | [URDF](https://github.com/david-dorf/perseverance-ingenuity-urdfs/tree/main/perseverance) | Apache-2.0 | ✔️ | ✖️ | ✖️ |
+| Tidybot | Stanford | [MJCF](https://github.com/google-deepmind/mujoco_menagerie/tree/main/stanford_tidybot) | MIT | ✔️ | ✔️ | ✔️ |
 
 ### Quadrupeds
 


### PR DESCRIPTION
This PR adds [Standford TidyBot](https://src.stanford.edu/demo/house-heroes-the-tidy-taskforce) to this repo!

MJCF URL: https://github.com/google-deepmind/mujoco_menagerie/tree/main/stanford_tidybot